### PR TITLE
add option to verify public user registrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,10 @@ If you use the [`response-field-name`](https://developers.cloudflare.com/turnsti
 Turnstile::getInstance()->validator->fails('custom-field');
 ```
 
+### Verifying public user registrations
+
+You can also verify Turnstile if you are using Craft's built-in controller action `save-user` (by using `{{ actionInput('users/save-user') }}` or `<input type="hidden" name="action" value="users/save-user">`). This behavior is turned off by default, but can be enabled on the plugin settings page or by setting `validateUserRegistrations` to `true` in the optional config file.
+
 ## Config
 You can customize the behavior of the widget using the `config` array.
 

--- a/src/config.php
+++ b/src/config.php
@@ -3,4 +3,5 @@
 return [
     'siteKey' => '',
     'secretKey' => '',
+    'validateUserRegistrations' => false,
 ];

--- a/src/models/Settings.php
+++ b/src/models/Settings.php
@@ -26,6 +26,13 @@ class Settings extends Model
     public $secretKey;
 
     /**
+     * Should public user registrations be validated?
+     *
+     * @var bool
+     */
+    public bool $validateUserRegistrations = false;
+
+    /**
      * The parsed site key.
      *
      * @return string

--- a/src/templates/_settings.twig
+++ b/src/templates/_settings.twig
@@ -23,3 +23,12 @@
     instructions: 'Enter Cloudflare Turnstile Secret Key here.',
     suggestEnvVars: true,
 }) }}
+
+{{ forms.lightswitchField({
+    label: 'Validate user registrations?'|t('turnstile'),
+    instructions: 'Enable to automatically validate Turnstile when using public user registration.'|t('turnstile'),
+    id: 'validateUserRegistrations',
+    name: 'validateUserRegistrations',
+    on: settings['validateUserRegistrations']
+  })
+}}


### PR DESCRIPTION
I implemented the feature I requested at #3. By default, the plugin will not verify public user registrations, so the default behaviour of the plugin as it is currently does not change. A toggle is added to the plugin settings to enable this behaviour.

Heavily inspired by https://github.com/c10d-dev/craft-recaptcha/